### PR TITLE
hide 'user joined the group' alerts

### DIFF
--- a/custom.css
+++ b/custom.css
@@ -44,7 +44,10 @@ div.linked-sender-name,
 /* CHAT_HIDE_REELS_OR_SIMILAR */
 div.message-container:has(> div > div > div > main > div.message-attachments-container):has(> div > div > div > main > div.message-footer),
 div.message-container:not(.hasSenderHash) div.message img.participant-img,
+/* CHAT_HIDE_IG_USER_IN_QUIET_MODE_ACTION */
 div.message-container.type-action:not(.hasSenderHash),
+/* CHAT_HIDE_USER_JOINED_ROOM_ACTION */
+div.message-container.type-action:has(> div > div > div > main > div > div > div > span.user-mention),
 div.message-icons,
 div.message-link,
 div.message-seen-by,


### PR DESCRIPTION
# problem

too many 'user joined the group' messages

<img width="754" alt="Screenshot 2024-05-01 at 23 05 37" src="https://github.com/clins777/texts-minimalist-theme/assets/1874643/59f9c022-3585-4cf6-a59a-28dd80263d8c">

# solution

hide it 😜 