### PR TITLE
truncate linked messages to optimize screen real estate and hide edited label

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ fair enough ...
 👉🏼 click 'reload css' button and your theme should now be applied.
 
 # 🫰🏼 features
+ℹ️ if you'd like to disable some features i've left a tag, such as `SIDEBAR_PLATFORM_ICON` for hiding platform icons on the sidebar, next to the feature so you can easily find it in the css and comment it out. not every feature has this at the moment. if you're having trouble disabling a specific feature, please submit an issue and i'll have a look for you.
 ### ⬅️ side bar
 - ✅ hide all, unread, archive tabs
 - ✅ hide time stamps in each message
@@ -56,6 +57,8 @@ fair enough ...
 - ✅ hide message reply sender names 
 - ✅ hide scroll bar
 - ✅ hide 'user is typing' notice
+- ✅ truncate linked messages to one liner
+- ✅ hide 'edited xm ago' labels on messages (`CHAT_MESSAGE_EDITED_LABEL`)
 ### 🤷🏻‍♂️ others
 - completely omitted reels or related content (`CHAT_HIDE_REELS_OR_SIMILAR`)
 - omitted platform icons on the sidebar (`SIDEBAR_PLATFORM_ICON`)

--- a/custom.css
+++ b/custom.css
@@ -63,6 +63,8 @@ div.typing-participants,
 div.unread-divider,
 /* SIDEBAR_PLATFORM_ICON */
 div.threads img.platform-icon,
+/* CHAT_MESSAGE_EDITED_LABEL */
+div.message-footer.message-edited-label,
 span.tooltip-wrapper {
   display: none;
 }

--- a/custom.css
+++ b/custom.css
@@ -16,6 +16,7 @@ To open dev tools, open the command bar and type "open console"
   --color-primary-rgb: 0, 0, 0;
   --left-pane-bg: var(--color-bg);
   --color-background-app: var(--color-bg);
+  --linked-message-width: 400px;
 }
 
 @media (prefers-color-scheme: dark) {
@@ -163,6 +164,14 @@ div.message-spacer {
 /* decrease horizontal padding for message replies */
 div.linked-message-content {
   padding: 0;
+}
+
+/* truncate and decrease height of linked message */
+div.linked-message-content .msg-text {
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  width: var(--linked-message-width);
 }
 
 div.linked-message {


### PR DESCRIPTION
# problem

linked messages take up unnecessary screen real estate

<img width="672" alt="Screenshot 2024-05-02 at 10 12 08" src="https://github.com/clins777/texts-minimalist-theme/assets/1874643/294b455c-963d-43be-83a4-ff3a979cfbbf">

# solution

truncate the message to a single line

<img width="669" alt="Screenshot 2024-05-02 at 10 12 25" src="https://github.com/clins777/texts-minimalist-theme/assets/1874643/2ba35195-01e4-42dc-b6c8-390076071646">

# others

also omitted 'edited' message alerts

also updated readme